### PR TITLE
fix(ci): use cache.numtide.com substituter for llm-agents.nix packages

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -11,12 +11,9 @@ runs:
       uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1
       with:
         github_access_token: ${{ github.token }}
-
-    - name: Setup Cachix (numtide)
-      uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
-      with:
-        name: numtide
-        authToken: ''
+        extra_nix_config: |
+          extra-substituters = https://cache.numtide.com
+          extra-trusted-public-keys = niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=
 
     - name: Setup Cachix (v01d42)
       uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16


### PR DESCRIPTION
## Summary

Point CI at numtide's new binary cache (`cache.numtide.com`) so llm-agents.nix packages (codex, claude-code, ccusage) are downloaded as prebuilt binaries instead of being compiled from source.

## Background

- `numtide/llm-agents.nix` pushes daily CI builds to `cache.numtide.com` (their niks3-based cache), and declares it in its flake `nixConfig` — which is ignored by default as untrusted flake config.
- Our `setup-nix` action was configured with the old numtide cachix cache (`numtide.cachix.org`), which no longer contains these builds.
- As a result, CI compiled codex (a full Rust cargo build) on every flake update touching llm-agents.

## Changes

- Add `cache.numtide.com` and its public key via `install-nix-action`'s `extra_nix_config` (written to the system `nix.conf` at install time, so always trusted).
- Remove the now-useless "Setup Cachix (numtide)" step.
- Keep the `v01d42` cachix step (used for pushing).

## Verification

- `nix path-info --store https://cache.numtide.com /nix/store/2pppi725qa1aqm3r27sm86xpzaly9jin-codex-0.144.6` → present.
- Same query against `https://numtide.cachix.org` → "path is not valid" (absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)